### PR TITLE
follow js-compute 1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "jest-preset.js",
   "license": "MIT",
   "devDependencies": {
-    "@fastly/js-compute": "^1.0.1",
+    "@fastly/js-compute": "^1.3.0",
     "@types/node": "^18.11.18",
     "@types/node-fetch": "^2.6.2",
     "@typescript-eslint/eslint-plugin": "^5.48.0",

--- a/src/globals.ts
+++ b/src/globals.ts
@@ -1,5 +1,5 @@
 /// <reference types="@fastly/js-compute" />
-import { getRandomValues, randomUUID } from "crypto";
+import { getRandomValues, randomUUID, subtle } from "crypto";
 import * as nodeFetch from "node-fetch";
 
 // ref: https://github.com/fastly/js-compute-runtime/blob/main/types/globals.d.ts
@@ -26,7 +26,19 @@ export class DecompressionStream {
   }
 }
 
-export const crypto = { getRandomValues, randomUUID };
+interface Algorithm {
+  name: string;
+}
+type AlgorithmIdentifier = Algorithm | string;
+type BufferSource = ArrayBufferView | ArrayBuffer;
+
+export const crypto = {
+  getRandomValues,
+  randomUUID,
+  subtle: {
+    digest: subtle.digest,
+  },
+};
 export const fetch: (
   input: RequestInfo,
   init?: RequestInit

--- a/yarn.lock
+++ b/yarn.lock
@@ -27,13 +27,14 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@fastly/js-compute@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@fastly/js-compute/-/js-compute-1.0.1.tgz#609b53e32f718528fe4eda9344249dc451f81886"
-  integrity sha512-vXmrlWIvDta4aFF8XXCPYI30Fgr1AM2nQlJvhIu/qqDzLdKpQ7iRdeNLihQLPHdvHDx/+gSYM8AD+hZN9itzMg==
+"@fastly/js-compute@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@fastly/js-compute/-/js-compute-1.3.0.tgz#3b97c3d8938b00b7e6e3ad5dd1d58cd80af0010e"
+  integrity sha512-+XZfEApQsv0FnuEprx+hv+l3+9+b5bPhnqbtipbuw9U/bDSPB7GGsdV3/YBH6biV9z5oAxvcpZQyckgyaLlnfw==
   dependencies:
     "@jakechampion/wizer" "^1.6.0"
     esbuild "^0.15.16"
+    js-component-tools "^0.2.2"
     tree-sitter "^0.20.1"
     tree-sitter-javascript "^0.19.0"
 
@@ -1489,6 +1490,11 @@ jest-util@^29.0.0:
     ci-info "^3.2.0"
     graceful-fs "^4.2.9"
     picomatch "^2.2.3"
+
+js-component-tools@^0.2.2:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/js-component-tools/-/js-component-tools-0.2.3.tgz#1f7e6ae5cb689746783daac0ef62419aff472266"
+  integrity sha512-hktKSgBaEk/Ttpl3ejBseeQn4K41wJijEA8YgxGXhyfCf5zT7YdEq1LYn+IYCPENEVgdcPK1c2ntbPKVjWeNJg==
 
 js-sdsl@^4.1.4:
   version "4.2.0"


### PR DESCRIPTION
Follows: https://github.com/fastly/js-compute-runtime/releases/tag/v1.3.0