### PR TITLE
add globalThis.fastly object

### DIFF
--- a/src/fastly-js-compute-mock.ts
+++ b/src/fastly-js-compute-mock.ts
@@ -107,7 +107,7 @@ export function allowDynamicBackends(enabled: boolean): void {
 }
 
 // ref: https://github.com/fastly/js-compute-runtime/blob/main/types/fastly:geolocation.d.ts
-interface Geolocation {
+export interface Geolocation {
   as_name: string | null;
   as_number: number | null;
   area_code: number | null;

--- a/src/globals.ts
+++ b/src/globals.ts
@@ -1,6 +1,14 @@
 /// <reference types="@fastly/js-compute" />
 import { getRandomValues, randomUUID, subtle } from "crypto";
 import * as nodeFetch from "node-fetch";
+import {
+  env,
+  Logger,
+  getGeolocationForIpAddress,
+  Geolocation,
+  enableDebugLogging,
+  includeBytes,
+} from "./fastly-js-compute-mock";
 
 // ref: https://github.com/fastly/js-compute-runtime/blob/main/types/globals.d.ts
 export class CompressionStream {
@@ -49,3 +57,40 @@ export function addEventListener<K extends keyof EventListenerMap>(
 ): void {
   // noop
 }
+
+// js-compute-runtime also provides globalThis.fastly object which includes some fields and method.
+// We should export them as global
+// ref: https://github.com/fastly/js-compute-runtime/issues/517
+export const fastly = {
+  __defaultBackend: "",
+
+  set baseURL(base: URL | null | undefined) {
+    // noop
+  },
+  get baseURL(): URL | null {
+    return null;
+  },
+  set defaultBackend(backend: string) {
+    this.__defaultBackend = backend;
+  },
+  get defaultBackend(): string {
+    return this.__defaultBackend;
+  },
+  env: {
+    get(name: string): string {
+      return env(name);
+    },
+  },
+  getLogger(endpoint: string): Logger {
+    return new Logger(endpoint);
+  },
+  enableDebugLogging(enabled: boolean) {
+    enableDebugLogging(enabled);
+  },
+  getGeolocationForIpAddress(address: string): Geolocation {
+    return getGeolocationForIpAddress(address);
+  },
+  includeBytes(path: string): Uint8Array {
+    return includeBytes(path);
+  },
+};

--- a/src/jest-preset.ts
+++ b/src/jest-preset.ts
@@ -6,6 +6,7 @@ import {
   DecompressionStream,
   crypto,
   fetch,
+  fastly,
 } from "./globals";
 
 export default {
@@ -15,6 +16,7 @@ export default {
     DecompressionStream,
     crypto,
     fetch,
+    fastly,
   },
   moduleNameMapper: {
     "^fastly:.*":

--- a/src/typescript/cjs/jest-preset.ts
+++ b/src/typescript/cjs/jest-preset.ts
@@ -7,6 +7,7 @@ import {
   DecompressionStream,
   crypto,
   fetch,
+  fastly,
 } from "../../globals";
 
 export default {
@@ -17,6 +18,7 @@ export default {
     DecompressionStream,
     crypto,
     fetch,
+    fastly,
   },
   moduleNameMapper: {
     "^fastly:.*":

--- a/src/typescript/esm/jest-preset.ts
+++ b/src/typescript/esm/jest-preset.ts
@@ -7,6 +7,7 @@ import {
   DecompressionStream,
   crypto,
   fetch,
+  fastly,
 } from "../../globals";
 
 export default {
@@ -17,6 +18,7 @@ export default {
     DecompressionStream,
     crypto,
     fetch,
+    fastly,
   },
   moduleNameMapper: {
     "^fastly:.*":


### PR DESCRIPTION
Corresponds to https://github.com/fastly/js-compute-runtime/issues/517, we will support `globalThis.fastly` object.
This object may be used for checking whether the runtime is Fastly.