### PR TITLE
Use setup files for global functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,4 +106,4 @@ dist
 fastly-js-compute-mock.js
 globals.js
 jest-preset.js
-typescript/
+/typescript/

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "build": "tsc",
     "prepare": "husky install",
     "lint-staged": "lint-staged",
-    "test": "jest"
+    "test": "tsc && jest"
   },
   "husky": {
     "hooks": {

--- a/src/fastly-js-compute-mock.ts
+++ b/src/fastly-js-compute-mock.ts
@@ -45,7 +45,7 @@ export class CacheOverride {
       swr?: number;
       surrogateKey?: string;
       pci?: boolean;
-    }
+    },
   ) {
     this.mode = mode;
     if (init) {

--- a/src/typescript/cjs/jest-preset.ts
+++ b/src/typescript/cjs/jest-preset.ts
@@ -1,23 +1,14 @@
 /// <reference types="@fastly/js-compute" />
 
-import {
-  addEventListener,
-  CompressionStream,
-  DecompressionStream,
-  crypto,
-  fetch,
-  fastly,
-} from "../../globals";
 import { join } from "node:path";
+
 export default {
-  globals: {
-    addEventListener,
-    CompressionStream,
-    DecompressionStream,
-    crypto,
-    fetch,
-    fastly,
-  },
+  // Jest document says that "globals" object must be json-serializable,
+  // so that we could not specify class instance which has methods and getter/setter due to lack on json serializinga.
+  // Then we should use setupFiles instead in order to specify global functions and classes
+  //
+  // @see: https://github.com/jestjs/jest/blob/main/docs/Configuration.md#globals-object
+  setupFiles: [join(__dirname, "./jest.setup.js")],
   moduleNameMapper: {
     "^fastly:.*": join(__dirname, "../../fastly-js-compute-mock.js"),
   },

--- a/src/typescript/cjs/jest.setup.ts
+++ b/src/typescript/cjs/jest.setup.ts
@@ -1,0 +1,18 @@
+import {
+  addEventListener,
+  CompressionStream,
+  DecompressionStream,
+  crypto,
+  fetch,
+  fastly,
+} from "../../globals";
+
+// Expose as "global" functions and classes
+Object.assign(globalThis, {
+  addEventListener,
+  CompressionStream,
+  DecompressionStream,
+  crypto,
+  fetch,
+  fastly,
+});

--- a/src/typescript/esm/jest-preset.ts
+++ b/src/typescript/esm/jest-preset.ts
@@ -1,25 +1,16 @@
 /// <reference types="@fastly/js-compute" />
 
 import defaultESM from "ts-jest/presets/default-esm/jest-preset";
-import {
-  addEventListener,
-  CompressionStream,
-  DecompressionStream,
-  crypto,
-  fetch,
-  fastly,
-} from "../../globals";
 import { join } from "node:path";
+
 export default {
   ...defaultESM,
-  globals: {
-    addEventListener,
-    CompressionStream,
-    DecompressionStream,
-    crypto,
-    fetch,
-    fastly,
-  },
+  // Jest document says that "globals" object must be json-serializable,
+  // so that we could not specify class instance which has methods and getter/setter due to lack on json serializinga.
+  // Then we should use setupFiles instead in order to specify global functions and classes
+  //
+  // @see: https://github.com/jestjs/jest/blob/main/docs/Configuration.md#globals-object
+  setupFiles: [join(__dirname, "./jest.setup.js")],
   moduleNameMapper: {
     "^fastly:.*": join(__dirname, "../../fastly-js-compute-mock.js"),
   },

--- a/src/typescript/esm/jest.setup.ts
+++ b/src/typescript/esm/jest.setup.ts
@@ -1,0 +1,18 @@
+import {
+  addEventListener,
+  CompressionStream,
+  DecompressionStream,
+  crypto,
+  fetch,
+  fastly,
+} from "../../globals";
+
+// Expose as "global" functions and classes
+Object.assign(globalThis, {
+  addEventListener,
+  CompressionStream,
+  DecompressionStream,
+  crypto,
+  fetch,
+  fastly,
+});


### PR DESCRIPTION
After we had testing from #10 , I found that the `global` object does not seem to work as well.
It causes by jest configuration, the document says we could not set an object which has some functions because they must be json-serializeable.

We solved it by using `setupFiles` configuration in preset, all tests are passed.